### PR TITLE
Fetch and compare all the configuration files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,14 @@ ThisBuild / scalaVersion     := "2.13.4"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.gu"
 ThisBuild / organizationName := "example"
+ThisBuild / scalacOptions ++= Seq(
+  "-Xfatal-warnings",
+  "-encoding", "UTF-8",
+  "-target:jvm-1.8",
+  "-Ywarn-dead-code",
+  "-deprecation",
+  "-explaintypes",
+)
 
 val awsSdkVersion = "2.16.25"
 

--- a/src/main/scala/com/gu/wazup/Logic.scala
+++ b/src/main/scala/com/gu/wazup/Logic.scala
@@ -64,7 +64,6 @@ object Logic {
   }
 
   def hasChanges(incoming: WazuhFiles, current: WazuhFiles): Boolean = {
-    implicit val fileOrder: Ordering[ConfigFile] = Ordering.by(_.filename)
     incoming.ossecConf != current.ossecConf ||
       incoming.otherConf.toSeq.sorted != current.otherConf.toSeq.sorted
   }

--- a/src/main/scala/com/gu/wazup/Logic.scala
+++ b/src/main/scala/com/gu/wazup/Logic.scala
@@ -74,7 +74,7 @@ object Logic {
 
   // TODO: decide if it would be helpful for this to indicate success / fail
   def writeConf(path: String, wazuhFiles: WazuhFiles): ZIO[Blocking, String, Unit] = {
-    writeTextFile(ConfigFile(s"$path/ossec.conf", wazuhFiles.ossecConf))
+    writeTextFile(s"$path/ossec.conf", wazuhFiles.ossecConf)
   }
 
   // should only be called if the conf has changed and should ideally return the status code
@@ -101,12 +101,12 @@ object Logic {
     }
   }
 
-  private def writeTextFile(configFile: ConfigFile): ZIO[Blocking, String, Unit] = {
+  private def writeTextFile(filePath: String, content: String): ZIO[Blocking, String, Unit] = {
     effectBlocking {
-      val file = new File(configFile.filename)
+      val file = new File(filePath)
       val writer = new BufferedWriter(new FileWriter(file))
       try {
-        writer.write(configFile.content)
+        writer.write(content)
       } finally {
         writer.close()
       }

--- a/src/main/scala/com/gu/wazup/Main.scala
+++ b/src/main/scala/com/gu/wazup/Main.scala
@@ -3,14 +3,14 @@ package com.gu.wazup
 import com.gu.wazup.aws.AWS
 import software.amazon.awssdk.regions.Region
 import zio.blocking.Blocking
-import zio.console._
+import zio.console.Console
 import zio.{ExitCode, URIO}
 
 
 object Main extends zio.App {
   private val s3Client = AWS.s3Client("infosec", Region.of("eu-west-1"))
-  private val systemsManagerClient = AWS.systemsManagerClient("infosec", Region.of("eu-west-1"))
-  private val cloudwatchClient = AWS.cloudwatchClient("infosec", Region.of("eu-west-1"))
+  private val ssmClient = AWS.ssmClient("infosec", Region.of("eu-west-1"))
+  private val cwClient = AWS.cloudwatchClient("infosec", Region.of("eu-west-1"))
 
   private val bucket = "BUCKET"
   private val bucketPath = "REPO/wazuh/etc"
@@ -18,5 +18,5 @@ object Main extends zio.App {
   private val confPath = "/var/ossec/etc/"
 
   def run(args: List[String]): URIO[Console with Blocking, ExitCode] =
-    Wazup.wazup(s3Client, systemsManagerClient, bucket, bucketPath, confPath, parameterPrefix).forever.exitCode
+    Wazup.wazup(s3Client, ssmClient, bucket, bucketPath, confPath, parameterPrefix).forever.exitCode
 }

--- a/src/main/scala/com/gu/wazup/Main.scala
+++ b/src/main/scala/com/gu/wazup/Main.scala
@@ -4,7 +4,7 @@ import com.gu.wazup.aws.AWS
 import software.amazon.awssdk.regions.Region
 import zio.blocking.Blocking
 import zio.console._
-import zio.{ExitCode, URIO, ZIO}
+import zio.{ExitCode, URIO}
 
 
 object Main extends zio.App {
@@ -12,33 +12,11 @@ object Main extends zio.App {
   private val systemsManagerClient = AWS.systemsManagerClient("infosec", Region.of("eu-west-1"))
   private val cloudwatchClient = AWS.cloudwatchClient("infosec", Region.of("eu-west-1"))
 
-  def run(args: List[String]): URIO[Console with Blocking, ExitCode] =
-    wazup.forever.exitCode
-
   private val bucket = "BUCKET"
   private val bucketPath = "REPO/wazuh/etc"
   private val parameterPrefix = "/wazuh/CODE/"
   private val confPath = "/var/ossec/etc/"
 
-  val wazup: ZIO[Console with Blocking, Serializable, Unit] = {
-    val result = for {
-      wazuhFiles <- AWS.fetchFiles(s3Client, bucket, bucketPath)
-      parameters <- AWS.fetchParameters(systemsManagerClient, parameterPrefix)
-      wazuhParameters = Logic.parseParameters(parameters, parameterPrefix)
-      // TODO: add validate parameters step and log to CloudWatch the result
-      nodeAddress <- Logic.getNodeAddress
-      nodeType = Logic.getNodeType(nodeAddress, wazuhParameters)
-      newConf = Logic.createConf(wazuhFiles, wazuhParameters, nodeType, nodeAddress)
-      currentConf <- Logic.getCurrentConf(confPath, List.empty)
-      shouldUpdate = Logic.hasChanges(newConf, currentConf)
-      // TODO: add CloudWatch logging step here
-      _ <- ZIO.when(shouldUpdate)(Logic.writeConf(confPath, newConf))
-      // TODO: add CloudWatch logging step here
-      returnCode <- ZIO.when(shouldUpdate)(Logic.restartWazuh())
-    } yield returnCode
-
-    // TODO: replace println with logging to CloudWatch
-    result.fold(err => println(err), identity)
-  }
-
+  def run(args: List[String]): URIO[Console with Blocking, ExitCode] =
+    Wazup.wazup(s3Client, systemsManagerClient, bucket, bucketPath, confPath, parameterPrefix).forever.exitCode
 }

--- a/src/main/scala/com/gu/wazup/Wazup.scala
+++ b/src/main/scala/com/gu/wazup/Wazup.scala
@@ -1,0 +1,65 @@
+package com.gu.wazup
+
+import com.gu.wazup.aws.S3
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.ssm.SsmAsyncClient
+import software.amazon.awssdk.services.ssm.model.{GetParametersByPathRequest, GetParametersByPathResponse}
+import zio.blocking.Blocking
+import zio.console.Console
+import zio.{IO, ZIO}
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+import scala.util.control.NonFatal
+
+
+object Wazup {
+  def wazup(s3Client: S3Client, systemsManagerClient: SsmAsyncClient, bucket: String, bucketPath: String, confPath: String, parameterPrefix: String): ZIO[Console with Blocking, Serializable, Unit] = {
+    val result = for {
+      configFiles <- fetchFiles(s3Client, bucket, bucketPath)
+      parameters <- fetchParameters(systemsManagerClient, parameterPrefix)
+      wazuhParameters = Logic.parseParameters(parameters, parameterPrefix)
+      // TODO: add validate parameters step and log to CloudWatch the result
+      nodeAddress <- Logic.getNodeAddress
+      nodeType = Logic.getNodeType(nodeAddress, wazuhParameters)
+      wazuhFiles <- IO.fromEither(Logic.getWazuhFiles(configFiles, bucketPath))
+      newConf = Logic.createConf(wazuhFiles, wazuhParameters, nodeType, nodeAddress)
+      currentConf <- Logic.getCurrentConf(confPath, List.empty)
+      shouldUpdate = Logic.hasChanges(newConf, currentConf)
+      // TODO: add CloudWatch logging step here
+      _ <- ZIO.when(shouldUpdate)(Logic.writeConf(confPath, newConf))
+      // TODO: check ZIO will wait for the conf to be written before restarting
+      // TODO: add CloudWatch logging step here
+      returnCode <- ZIO.when(shouldUpdate)(Logic.restartWazuh())
+    } yield returnCode
+
+    // TODO: replace println with logging to CloudWatch
+    result.fold(err => println(err), identity)
+  }
+
+  private def getConfigFile(client: S3Client, bucket: String, key: String): ZIO[Blocking, String, ConfigFile] = {
+    S3.getObjectContent(client, bucket, key).map(content => ConfigFile(key, content))
+  }
+
+  // TODO: change left to be a failure so we can return more information
+  def fetchFiles(client: S3Client, bucket: String, prefix: String): ZIO[Blocking, String, List[ConfigFile]] = {
+    for {
+      response <- S3.listObjects(client, bucket, prefix)
+      objectList = response.contents.asScala.toList
+      configFiles <- ZIO.validatePar(objectList)(obj =>
+        getConfigFile(client, bucket, obj.key)).mapError(_.mkString(" "))
+    } yield configFiles
+  }
+
+  // TODO: check pagination =- do we want to use getParametersByPathPaginator?
+  def fetchParameters(client: SsmAsyncClient, prefix: String): IO[String, GetParametersByPathResponse] = {
+    val request = GetParametersByPathRequest.builder()
+      .path(prefix)
+      .withDecryption(true)
+      .recursive(true)
+      .build()
+    ZIO.fromFuture(implicit ec => client.getParametersByPath(request).asScala).refineOrDie {
+      case NonFatal(t) => t.getMessage
+    }
+  }
+}

--- a/src/main/scala/com/gu/wazup/aws/AWS.scala
+++ b/src/main/scala/com/gu/wazup/aws/AWS.scala
@@ -24,7 +24,7 @@ object AWS {
       .build()
   }
 
-  def systemsManagerClient(profile: String, region: Region): SsmAsyncClient = {
+  def ssmClient(profile: String, region: Region): SsmAsyncClient = {
     SsmAsyncClient.builder()
       .credentialsProvider(credentialsProvider(profile))
       .region(region)

--- a/src/main/scala/com/gu/wazup/aws/AWS.scala
+++ b/src/main/scala/com/gu/wazup/aws/AWS.scala
@@ -1,19 +1,10 @@
 package com.gu.wazup.aws
 
-import com.gu.wazup.{ConfigFile, WazuhFiles}
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, InstanceProfileCredentialsProvider, ProfileCredentialsProvider}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
 import software.amazon.awssdk.services.ssm.SsmAsyncClient
-import software.amazon.awssdk.services.ssm.model.{GetParametersByPathRequest, GetParametersByPathResponse}
-import zio.blocking.Blocking
-import zio.{IO, ZIO}
-
-import scala.jdk.CollectionConverters._
-import scala.jdk.FutureConverters._
-import scala.util.control.NonFatal
 
 
 object AWS {
@@ -45,27 +36,5 @@ object AWS {
       .credentialsProvider(credentialsProvider(profile))
       .region(region)
       .build()
-  }
-
-  // TODO: change left to be a failure so we can return more information
-  def fetchFiles(client: S3Client, bucket: String, prefix: String): ZIO[Blocking, String, WazuhFiles] = {
-    for {
-      ossecConf <- S3.getObjectContent(client, bucket, s"$prefix/ossec.conf")
-      decoders <- S3.listObjects(client, bucket, s"$prefix/decoders/")
-      lists <- S3.listObjects(client, bucket, s"$prefix/lists/")
-      rules <- S3.listObjects(client, bucket, s"$prefix/rules/")
-    } yield WazuhFiles(ossecConf)
-  }
-
-  // TODO: check pagination =- do we want to use getParametersByPathPaginator?
-  def fetchParameters(client: SsmAsyncClient, prefix: String): IO[String, GetParametersByPathResponse] = {
-    val request = GetParametersByPathRequest.builder()
-      .path(prefix)
-      .withDecryption(true)
-      .recursive(true)
-      .build()
-    ZIO.fromFuture(implicit ec => client.getParametersByPath(request).asScala).refineOrDie {
-      case NonFatal(t) => t.getMessage
-    }
   }
 }

--- a/src/main/scala/com/gu/wazup/models.scala
+++ b/src/main/scala/com/gu/wazup/models.scala
@@ -20,12 +20,7 @@ case class WazuhParameters(
 
 case class WazuhFiles(
   ossecConf: String,
-  // decoders/ contains one or more files
-  decoders: List[ConfigFile] = List.empty,
-  // lists/ contains one or more files
-  lists: List[ConfigFile] = List.empty,
-  // rules/ contains one or more files
-  rules: List[ConfigFile] = List.empty,
+  otherConf: List[ConfigFile] = List.empty,
 )
 
 case class ConfigFile(

--- a/src/main/scala/com/gu/wazup/models.scala
+++ b/src/main/scala/com/gu/wazup/models.scala
@@ -27,3 +27,6 @@ case class ConfigFile(
   filename: String,
   content: String,
 )
+object ConfigFile {
+  implicit val ordering: Ordering[ConfigFile] = Ordering.by(_.filename)
+}

--- a/src/test/resources/ossec/cluster-leader-output.conf
+++ b/src/test/resources/ossec/cluster-leader-output.conf
@@ -1,7 +1,7 @@
 <ossec_config>
   <cluster>
     <name>wazuh</name>
-    <node_name>leader</node_name>
+    <node_name>leader-10.0.0.1</node_name>
     <node_type>master</node_type>
     <key>12345FAKEKEY</key>
     <port>1516</port>

--- a/src/test/resources/ossec/cluster-worker-output.conf
+++ b/src/test/resources/ossec/cluster-worker-output.conf
@@ -1,7 +1,7 @@
 <ossec_config>
   <cluster>
     <name>wazuh</name>
-    <node_name>worker</node_name>
+    <node_name>worker-10.0.0.1</node_name>
     <node_type>worker</node_type>
     <key>12345FAKEKEY</key>
     <port>1516</port>

--- a/src/test/scala/com/gu/wazup/LogicTest.scala
+++ b/src/test/scala/com/gu/wazup/LogicTest.scala
@@ -47,14 +47,14 @@ class LogicTest extends AnyFreeSpec with Matchers {
     )
 
     "generates the correct configuration for a Leader" in {
-      val testConf = Source.fromResource("ossec/cluster-input.conf").getLines.mkString("\n")
-      val expectedConf = Source.fromResource("ossec/cluster-leader-output.conf").getLines.mkString("\n")
+      val testConf = Source.fromResource("ossec/cluster-input.conf").getLines().mkString("\n")
+      val expectedConf = Source.fromResource("ossec/cluster-leader-output.conf").getLines().mkString("\n")
       Logic.createConf(WazuhFiles(testConf), parameters, Leader, "10.0.0.1") shouldEqual WazuhFiles(expectedConf)
     }
 
     "generates the correct configuration for a Worker" in {
-      val testConf = Source.fromResource("ossec/cluster-input.conf").getLines.mkString("\n")
-      val expectedConf = Source.fromResource("ossec/cluster-worker-output.conf").getLines.mkString("\n")
+      val testConf = Source.fromResource("ossec/cluster-input.conf").getLines().mkString("\n")
+      val expectedConf = Source.fromResource("ossec/cluster-worker-output.conf").getLines().mkString("\n")
       Logic.createConf(WazuhFiles(testConf), parameters, Worker, "10.0.0.1") shouldEqual WazuhFiles(expectedConf)
     }
   }


### PR DESCRIPTION
## What is the purpose of this change?

Implement the remaining steps required to make Wazup a functioning program 😁
Wazup now fetches and compares all the configuration files, including those under `/decoders`, `/lists` and `/rules`.

An implicit ordering has been added to the `ConfigFile` so they will sort via the `filename` 🥳 

This PR also includes a reshuffle of the location of the program and sub-programs into the new `Wazup.scala`.


## What is the value of this change and how do we measure success?

We can deploy a Wazuh cluster where the leader and workers can all pick up configuration changes on a regular basis and configuration can be centralised.

## Any additional notes?

