### PR TITLE
Enable wazup to be built as a debian package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 # Wazup
 
 Automated deployment of Wazuh configuration files
+_____
+
+[Wazuh](https://github.com/wazuh/wazuh) is an open source platform for threat detection, security monitoring and incident response. It can be used to monitor endpoints, cloud services and containers, and to aggregate and analyze data from external sources.
+
+Wazup is intended to be run on every node in a [Wazuh cluster](https://documentation.wazuh.com/current/user-manual/configuring-cluster/basics.html) and handles the entire lifecycle of the Wazuh manager, including starting the service for the first time.
+
+## Purpose
+
+Wazup allows a single, centralised source of configuration that can be polled by each node in the cluster. Wazup polls the storage location of the configuration, customises the configuration depending on the node type and inserts missing secrets.
+
+Additionally, the configuration can be kept under version control and follow a change management system whereby updates are reviewed and approved before they are applied to production.
+
+Wazup removes the requirement for anyone to ssh onto an instance to change the configuration.
+
+## Deploying Wazup
+
+Wazup does not yet have automated builds or deployment.
+
+The debian package can be created with the sbt-native-packager:
+
+```
+sbt debian:packageBin
+```
+
+Once the package has been built, use the AWS command line tools to upload it to S3:
+
+```
+aws s3 cp target/wazup.deb s3://$BUCKET_NAME/$STACK/$STAGE/ --profile $PROFILE
+```

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
+import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
+
 ThisBuild / scalaVersion     := "2.13.4"
-ThisBuild / version          := "0.1.0-SNAPSHOT"
+ThisBuild / version          := "0.1.0"
 ThisBuild / organization     := "com.gu"
-ThisBuild / organizationName := "example"
 ThisBuild / scalacOptions ++= Seq(
   "-Xfatal-warnings",
   "-encoding", "UTF-8",
@@ -14,6 +15,7 @@ ThisBuild / scalacOptions ++= Seq(
 val awsSdkVersion = "2.16.25"
 
 lazy val root = (project in file("."))
+  .enablePlugins(JavaServerAppPackaging, JDebPackaging, SystemdPlugin)
   .settings(
     name := "wazup",
     libraryDependencies ++= Seq(
@@ -25,5 +27,10 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "cloudwatch" % awsSdkVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
       "org.scalatest" %% "scalatest" % "3.2.2" % Test
-    )
+    ),
+    serverLoading in Debian := Some(Systemd),
+    debianPackageDependencies := Seq("java8-runtime-headless"),
+    maintainer in Debian := "Security Engineering",
+    packageSummary in Debian := "Wazup: Automatically update Wazuh configuration",
+    packageDescription in Debian := "Wazup: Automatically update Wazuh configuration",
   )

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ lazy val root = (project in file("."))
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
       "org.scalatest" %% "scalatest" % "3.2.2" % Test
     ),
+    daemonGroup in Linux := "ossec",
     serverLoading in Debian := Some(Systemd),
     debianPackageDependencies := Seq("java8-runtime-headless"),
     maintainer in Debian := "Security Engineering",

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,10 @@
 import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
 
 ThisBuild / scalaVersion     := "2.13.4"
-ThisBuild / version          := "0.1.0"
+ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.gu"
+ThisBuild / organizationName := "The Guardian"
+
 ThisBuild / scalacOptions ++= Seq(
   "-Xfatal-warnings",
   "-encoding", "UTF-8",
@@ -28,9 +30,12 @@ lazy val root = (project in file("."))
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
       "org.scalatest" %% "scalatest" % "3.2.2" % Test
     ),
-    daemonGroup in Linux := "ossec",
     serverLoading in Debian := Some(Systemd),
     debianPackageDependencies := Seq("java8-runtime-headless"),
+    // daemonUser and daemonGroup must be scoped to Linux to be applied
+    // membership of ossec gives wazup permission to modify /var/ossec/
+    daemonGroup in Linux := "ossec",
+
     maintainer in Debian := "Security Engineering",
     packageSummary in Debian := "Wazup: Automatically update Wazuh configuration",
     packageDescription in Debian := "Wazup: Automatically update Wazuh configuration",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,5 @@
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
+
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")

--- a/src/main/scala/com/gu/wazup/Wazup.scala
+++ b/src/main/scala/com/gu/wazup/Wazup.scala
@@ -81,7 +81,6 @@ object Wazup {
     }).mapError(_.mkString(" "))
   }
 
-  // TODO: check if sudo is needed to restart and work out how to avoid running as root
   def restartWazuh(): ZIO[Blocking, CommandError, ExitCode] = {
     Command("systemctl", "restart", "wazuh-manager").run
       .flatMap(process => process.exitCode)


### PR DESCRIPTION
## What is the purpose of this change?

To enable wazup to be built as a debian package so that it can be installed and started as a service.

## What is the value of this change and how do we measure success?

Wazup can be deployed to the EC2 instances that will form our Wazuh Cluster 🚀 🌔 

I have deployed this onto a test instance and the service ran okay and even started the wazuh-manager 🥳 

## Any additional notes?

The default behaviour of sbt-native-packager would be to set the user group to the name of the package. However, membership of `ossec` gives `wazup` permission to modify `/var/ossec/` which is created by the installation process of the wazuh-manger.

This PR also expands the README to provide information on the purpose of wazup and how it can be used.