### PR TITLE
Add pull request and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+## Summary of issue
+<!-- add a concise description of what the bug is -->
+
+
+## Steps to reproduce the behavior
+
+
+
+## Actual Results
+<!-- Remember to redact any secret or private information! -->
+<!-- Screenshots will help explain your problem -->
+
+
+## Expected Results
+<!-- Remember to redact any secret or private information! -->
+<!-- Screenshots will help explain your problem -->
+
+
+## Additional context
+<!-- Please add any other context about the problem here -->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature request
+assignees: ''
+
+---
+
+## What problem would this feature solve?
+<!-- Please describe the problem this feature would solve and the requirements you have -->
+
+
+## Alternative options or solutions
+<!-- Please describe any alternatives you have considered -->
+
+
+## Additional context
+<!--
+Please add any other context or screenshots about the feature request here. This could include
+ the source of the inspiration for the feature (such as a different service) or examples of how
+ the feature might work.
+-->
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!-- 
+Hello and thank you for contributing! Please try to complete each section below.
+For some guidance on how to write great pull requests, see our recommendations:
+https://github.com/guardian/recommendations/blob/master/pull-requests.md 😁
+-->
+
+## What is the purpose of this change?
+
+
+## What is the value of this change and how do we measure success?
+
+
+## Any additional notes?
+


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! Please try to complete each section below.
For some guidance on how to write great pull requests, see our recommendations:
https://github.com/guardian/recommendations/blob/master/pull-requests.md 😁
-->

## What is the purpose of this change?

Add two issue templates that work with GitHub and cover the most common issues; feature request and bug report. When opening an issue on GitHub users will be asked to select the type of issue, which will look something like this:

<img width="677" alt="Screenshot 2020-07-03 at 00 07 40" src="https://user-images.githubusercontent.com/8607683/86416214-3f9a2c80-bcc1-11ea-91ce-0727adfe6aed.png">

## What is the value of this change?

Issue templates that prompt for desired information will support both feature requests and bug reports. We can ask different questions based on the type of the issue being opened (if I have understood and applied the [GitHub documentation](https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates) correctly).

The Pull Request template asks some of the general questions that can be helpful when reviewing. This should hopefully reduce the number of follow up questions that maintainers need to ask.

## How do we measure success?

Opening an issue provides these templates rather than falling back to the organisation level template. 🤞


## Any additional notes?

Nope.
