### PR TITLE
Improve Logging for Wazup and configure log ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,26 @@ Additionally, the configuration can be kept under version control and follow a c
 
 Wazup removes the requirement for anyone to ssh onto an instance to change the configuration.
 
-## Deploying Wazup
+## Development
+
+You will need to create a local configuration file; ideally in an alternative directory to minimise the risk of it being committed to the repository.
+
+The configuration can use HOCON format and requires the following entries:
+
+```
+wazup {
+  bucket = ???
+  bucketPath = ???
+  parameterPrefix = ???
+  confPath = ???
+}
+```
+
+Run Wazup with sbt and provide the path to the local configuration file:
+
+    sbt -Dconfig.file=<PATH>/wazup.local.conf run
+
+## Deployment
 
 Wazup does not yet have automated builds or deployment.
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "wazup",
     libraryDependencies ++= Seq(
+      "com.typesafe" % "config" % "1.4.1",
       "dev.zio" %% "zio" % "1.0.5",
       "dev.zio" %% "zio-process" % "0.3.0",
       "joda-time" % "joda-time" % "2.10.6",

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,8 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "auth" % awsSdkVersion,
       "software.amazon.awssdk" % "ssm" % awsSdkVersion,
       "software.amazon.awssdk" % "cloudwatch" % awsSdkVersion,
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.3",
+      "ch.qos.logback" % "logback-classic" % "1.2.3",
       "org.scalatest" %% "scalatest" % "3.2.2" % Test
     ),
     serverLoading in Debian := Some(Systemd),

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio" % "1.0.5",
       "dev.zio" %% "zio-process" % "0.3.0",
+      "joda-time" % "joda-time" % "2.10.6",
       "software.amazon.awssdk" % "s3" % awsSdkVersion,
       "software.amazon.awssdk" % "auth" % awsSdkVersion,
       "software.amazon.awssdk" % "ssm" % awsSdkVersion,

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,32 @@
+<configuration>
+
+    <contextName>wazup</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/wazup.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/wazup.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date{yyyy-MM-dd HH:mm:ss ZZZZ} %-5level %logger{0} %-16([%thread]) - %msg%n%xException{3}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %logger{0} %-16([%thread]) - %msg%n%xException{3}</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.gu.wazup" level="TRACE" />
+    <logger name="software.amazon" level="WARN" />
+
+    <root level="INFO">
+        <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,13 +11,13 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date{yyyy-MM-dd HH:mm:ss ZZZZ} %-5level %logger{0} %-16([%thread]) - %msg%n%xException{3}</pattern>
+            <pattern>%date{yyyy-MM-dd HH:mm:ss ZZZZ} %-5level %logger{0} %-22([%thread]) - %msg%n%xException{3}</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %logger{0} %-16([%thread]) - %msg%n%xException{3}</pattern>
+            <pattern>%date{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %logger{0} %-22([%thread]) - %msg%n%xException{3}</pattern>
         </encoder>
     </appender>
 

--- a/src/main/scala/com/gu/wazup/Date.scala
+++ b/src/main/scala/com/gu/wazup/Date.scala
@@ -1,0 +1,16 @@
+package com.gu.wazup
+
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.{DateTime, DateTimeZone}
+
+object Date {
+  private val simpleDateFormatter = DateTimeFormat.forPattern("yyyy-MMM-dd").withZoneUTC()
+
+  def formatDate(date: DateTime): String = {
+    simpleDateFormatter.print(date).toUpperCase
+  }
+
+  def today: DateTime = {
+    DateTime.now(DateTimeZone.UTC).withTimeAtStartOfDay
+  }
+}

--- a/src/main/scala/com/gu/wazup/Logic.scala
+++ b/src/main/scala/com/gu/wazup/Logic.scala
@@ -23,9 +23,6 @@ object Logic {
       // TODO: should missing parameters raise an exception?
       parameters.get("cluster-key"),
       parameters.get("leader-address"),
-      parameters.get("cloudtrail-role-arn"),
-      parameters.get("guardduty-role-arn"),
-      parameters.get("umbrella-role-arn"),
     )
   }
 
@@ -40,13 +37,13 @@ object Logic {
   }
 
   // TODO: ossec.conf should be valid XML, can we return XML or add a method to validate the conf?
-  def createConf(wazuhFiles: WazuhFiles, parameters: WazuhParameters, nodeType: NodeType, nodeAddress: String, currentDate: DateTime): WazuhFiles = {
+  def createConf(wazuhFiles: WazuhFiles, parameters: WazuhParameters, nodeType: NodeType, nodeAddress: String, logsAfter: DateTime): WazuhFiles = {
     val nodeName = s"${nodeType.toString.toLowerCase}-$nodeAddress"
     val newConf = wazuhFiles.ossecConf
       .replaceAll("<node_name>.+</node_name>", s"<node_name>$nodeName</node_name>")
       .replaceAll("<key>.+</key>", s"<key>${parameters.clusterKey.getOrElse("")}</key>")
       .replaceAll("<node>.+</node>", s"<node>${parameters.leaderAddress.getOrElse("")}</node>")
-      .replaceAll("<only_logs_after>.+</only_logs_after>", s"<only_logs_after>${Date.formatDate(Date.today)}</only_logs_after>")
+      .replaceAll("<only_logs_after>.+</only_logs_after>", s"<only_logs_after>${Date.formatDate(logsAfter)}</only_logs_after>")
     if (nodeType == Worker) wazuhFiles.copy(ossecConf = configureWorker(newConf))
     else wazuhFiles.copy(ossecConf = newConf)
   }

--- a/src/main/scala/com/gu/wazup/Logic.scala
+++ b/src/main/scala/com/gu/wazup/Logic.scala
@@ -21,11 +21,11 @@ object Logic {
 
     WazuhParameters(
       // TODO: should missing parameters raise an exception?
-      parameters.get("wazuhClusterKey"),
-      parameters.get("coordinatorIP"),
-      parameters.get("cloudtrailRoleArn"),
-      parameters.get("guarddutyRoleArn"),
-      parameters.get("umbrellaRoleArn"),
+      parameters.get("cluster-key"),
+      parameters.get("leader-address"),
+      parameters.get("cloudtrail-role-arn"),
+      parameters.get("guardduty-role-arn"),
+      parameters.get("umbrella-role-arn"),
     )
   }
 
@@ -44,8 +44,8 @@ object Logic {
     val nodeName = s"${nodeType.toString.toLowerCase}-$nodeAddress"
     val newConf = wazuhFiles.ossecConf
       .replaceAll("<node_name>.+</node_name>", s"<node_name>$nodeName</node_name>")
-      .replaceAll("<key>.+</key>", s"<key>${parameters.wazuhClusterKey.getOrElse("")}</key>")
-      .replaceAll("<node>.+</node>", s"<node>${parameters.coordinatorIP.getOrElse("")}</node>")
+      .replaceAll("<key>.+</key>", s"<key>${parameters.clusterKey.getOrElse("")}</key>")
+      .replaceAll("<node>.+</node>", s"<node>${parameters.leaderAddress.getOrElse("")}</node>")
       .replaceAll("<only_logs_after>.+</only_logs_after>", s"<only_logs_after>${Date.formatDate(Date.today)}</only_logs_after>")
     if (nodeType == Worker) wazuhFiles.copy(ossecConf = configureWorker(newConf))
     else wazuhFiles.copy(ossecConf = newConf)
@@ -56,7 +56,7 @@ object Logic {
   }
 
   def getNodeType(instanceIp: String, parameters: WazuhParameters): NodeType = {
-    if (parameters.coordinatorIP.contains(instanceIp)) Leader
+    if (parameters.leaderAddress.contains(instanceIp)) Leader
     else Worker
   }
 

--- a/src/main/scala/com/gu/wazup/Main.scala
+++ b/src/main/scala/com/gu/wazup/Main.scala
@@ -1,6 +1,7 @@
 package com.gu.wazup
 
 import com.gu.wazup.aws.AWS
+import com.gu.wazup.config.WazupConfig
 import software.amazon.awssdk.regions.Region
 import zio.blocking.Blocking
 import zio.console.Console
@@ -12,11 +13,9 @@ object Main extends zio.App {
   private val ssmClient = AWS.ssmClient("infosec", Region.of("eu-west-1"))
   private val cwClient = AWS.cloudwatchClient("infosec", Region.of("eu-west-1"))
 
-  private val bucket = "BUCKET"
-  private val bucketPath = "REPO/wazuh/etc"
-  private val parameterPrefix = "/wazuh/CODE/"
-  private val confPath = "/var/ossec/etc/"
+  private val config = WazupConfig.load()
 
   def run(args: List[String]): URIO[Console with Blocking, ExitCode] =
-    Wazup.wazup(s3Client, ssmClient, bucket, bucketPath, confPath, parameterPrefix).forever.exitCode
+    Wazup.wazup(s3Client, ssmClient, config)
+      .forever.exitCode
 }

--- a/src/main/scala/com/gu/wazup/Wazup.scala
+++ b/src/main/scala/com/gu/wazup/Wazup.scala
@@ -36,7 +36,6 @@ object Wazup extends LazyLogging {
       // TODO: add CloudWatch logging step here
     } yield logger.info(s"Run complete! restart required was: $shouldUpdate")
 
-    // TODO: replace println with logging to CloudWatch
     result.fold(err => logger.error(err.toString), identity)
   }
 

--- a/src/main/scala/com/gu/wazup/config/WazupConfig.scala
+++ b/src/main/scala/com/gu/wazup/config/WazupConfig.scala
@@ -1,0 +1,34 @@
+package com.gu.wazup.config
+
+import com.gu.wazup.Configuration
+import com.typesafe.config.{Config, ConfigException, ConfigFactory}
+
+import scala.util.Try
+
+
+object WazupConfig {
+
+  def load(): Configuration = {
+    loadContents(ConfigFactory.load()).fold(
+      { errMsg =>
+        throw new WazupConfigException(s"Failed to load configuration: $errMsg")
+      },
+      identity
+    )
+  }
+
+  private def loadContents(config: Config): Either[String, Configuration] = {
+    for {
+      bucket <- handleErrors(config, "wazup.bucket")
+      bucketPath <- handleErrors(config, "wazup.bucketPath")
+      parameterPrefix <- handleErrors(config, "wazup.parameterPrefix")
+      confPath <- handleErrors(config, "wazup.confPath")
+    } yield Configuration(bucket, bucketPath, parameterPrefix, confPath)
+  }
+
+  private def handleErrors(config: Config, path: String): Either[String, String] = {
+    Try(config.getString(path)).toEither.left.map(_.getMessage)
+  }
+
+  class WazupConfigException(message: String) extends ConfigException(message)
+}

--- a/src/main/scala/com/gu/wazup/models.scala
+++ b/src/main/scala/com/gu/wazup/models.scala
@@ -5,6 +5,13 @@ sealed trait NodeType
 case object Leader extends NodeType
 case object Worker extends NodeType
 
+case class Configuration(
+  bucket: String,
+  bucketPath: String,
+  parameterPrefix: String,
+  confPath: String,
+)
+
 case class WazuhConf(
   wazuhParameters: WazuhParameters,
   wazuhFiles: WazuhFiles,

--- a/src/main/scala/com/gu/wazup/models.scala
+++ b/src/main/scala/com/gu/wazup/models.scala
@@ -11,8 +11,8 @@ case class WazuhConf(
 )
 
 case class WazuhParameters(
-  wazuhClusterKey: Option[String],
-  coordinatorIP: Option[String],
+  clusterKey: Option[String],
+  leaderAddress: Option[String],
   cloudtrailRoleArn: Option[String],
   guarddutyRoleArn: Option[String],
   umbrellaRoleArn: Option[String],

--- a/src/main/scala/com/gu/wazup/models.scala
+++ b/src/main/scala/com/gu/wazup/models.scala
@@ -20,9 +20,6 @@ case class WazuhConf(
 case class WazuhParameters(
   clusterKey: Option[String],
   leaderAddress: Option[String],
-  cloudtrailRoleArn: Option[String],
-  guarddutyRoleArn: Option[String],
-  umbrellaRoleArn: Option[String],
 )
 
 case class WazuhFiles(

--- a/src/test/resources/ossec/cluster-input.conf
+++ b/src/test/resources/ossec/cluster-input.conf
@@ -20,11 +20,13 @@
     <bucket type="cloudtrail">
       <name>wazuh-aws-wodle</name>
       <path>cloudtrail</path>
+      <only_logs_after>date</only_logs_after>
       <aws_profile>wazuh-aws-profile</aws_profile>
     </bucket>
     <bucket type="guardduty">
       <name>wazuh-aws-wodle</name>
       <path>guardduty</path>
+      <only_logs_after>date</only_logs_after>
       <aws_profile>wazuh-aws-profile</aws_profile>
     </bucket>
   </wodle>

--- a/src/test/resources/ossec/cluster-leader-output.conf
+++ b/src/test/resources/ossec/cluster-leader-output.conf
@@ -20,11 +20,13 @@
     <bucket type="cloudtrail">
       <name>wazuh-aws-wodle</name>
       <path>cloudtrail</path>
+      <only_logs_after>2021-JUN-03</only_logs_after>
       <aws_profile>wazuh-aws-profile</aws_profile>
     </bucket>
     <bucket type="guardduty">
       <name>wazuh-aws-wodle</name>
       <path>guardduty</path>
+      <only_logs_after>2021-JUN-03</only_logs_after>
       <aws_profile>wazuh-aws-profile</aws_profile>
     </bucket>
   </wodle>

--- a/src/test/resources/ossec/cluster-worker-output.conf
+++ b/src/test/resources/ossec/cluster-worker-output.conf
@@ -1,7 +1,7 @@
 <ossec_config>
   <cluster>
     <name>wazuh</name>
-    <node_name>worker-10.0.0.1</node_name>
+    <node_name>worker-10.0.0.2</node_name>
     <node_type>worker</node_type>
     <key>12345FAKEKEY</key>
     <port>1516</port>

--- a/src/test/scala/com/gu/wazup/LogicTest.scala
+++ b/src/test/scala/com/gu/wazup/LogicTest.scala
@@ -1,5 +1,6 @@
 package com.gu.wazup
 
+import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.ssm.model.{GetParametersByPathResponse, Parameter}
@@ -13,22 +14,19 @@ class LogicTest extends AnyFreeSpec with Matchers {
     "creates the WazuhParameters" in {
       val response = {
         GetParametersByPathResponse.builder().parameters(
-          Parameter.builder().name("/wazuh/TEST/wazuhClusterKey").value("FAKEKEY").build(),
-          Parameter.builder().name("/wazuh/TEST/coordinatorIP").value("10.0.0.1").build(),
-          Parameter.builder().name("/wazuh/TEST/cloudtrailRoleArn").value("arn:cloudtrail").build(),
-          Parameter.builder().name("/wazuh/TEST/guarddutyRoleArn").value("arn:guardduty").build(),
-          Parameter.builder().name("/wazuh/TEST/umbrellaRoleArn").value("arn:umbrella").build(),
+          Parameter.builder().name("/wazuh/TEST/cluster-key").value("FAKEKEY").build(),
+          Parameter.builder().name("/wazuh/TEST/leader-address").value("10.0.0.1").build(),
         ).build()
       }
       val expected = WazuhParameters(
-        Some("FAKEKEY"), Some("10.0.0.1"), Some("arn:cloudtrail"), Some("arn:guardduty"), Some("arn:umbrella"))
+        Some("FAKEKEY"), Some("10.0.0.1"))
 
       Logic.parseParameters(response, "/wazuh/TEST/") shouldEqual expected
     }
   }
 
   "getNodeType" - {
-    val parameters = WazuhParameters(None, Some("10.0.0.1"), None, None, None)
+    val parameters = WazuhParameters(None, Some("10.0.0.1"))
 
     "returns Leader when the addresses match" in {
       Logic.getNodeType("10.0.0.1", parameters) shouldEqual Leader
@@ -57,21 +55,20 @@ class LogicTest extends AnyFreeSpec with Matchers {
     val parameters: WazuhParameters = WazuhParameters(
       Some("12345FAKEKEY"),
       Some("10.0.0.1"),
-      Some("cloudtrailRoleArn"),
-      Some("guarddutyRoleArn"),
-      Some("umbrellaRoleArn")
     )
 
     "generates the correct configuration for a Leader" in {
+      val dateTime: DateTime = new DateTime(2021, 6, 3, 12, 30, DateTimeZone.UTC)
       val testConf = Source.fromResource("ossec/cluster-input.conf").getLines().mkString("\n")
       val expectedConf = Source.fromResource("ossec/cluster-leader-output.conf").getLines().mkString("\n")
-      Logic.createConf(WazuhFiles(testConf), parameters, Leader, "10.0.0.1", Date.today) shouldEqual WazuhFiles(expectedConf)
+      Logic.createConf(WazuhFiles(testConf), parameters, Leader, "10.0.0.1", dateTime) shouldEqual WazuhFiles(expectedConf)
     }
 
     "generates the correct configuration for a Worker" in {
+      val dateTime: DateTime = new DateTime(2021, 6, 3, 12, 30, DateTimeZone.UTC)
       val testConf = Source.fromResource("ossec/cluster-input.conf").getLines().mkString("\n")
       val expectedConf = Source.fromResource("ossec/cluster-worker-output.conf").getLines().mkString("\n")
-      Logic.createConf(WazuhFiles(testConf), parameters, Worker, "10.0.0.2", Date.today) shouldEqual WazuhFiles(expectedConf)
+      Logic.createConf(WazuhFiles(testConf), parameters, Worker, "10.0.0.2", dateTime) shouldEqual WazuhFiles(expectedConf)
     }
   }
 }

--- a/src/test/scala/com/gu/wazup/LogicTest.scala
+++ b/src/test/scala/com/gu/wazup/LogicTest.scala
@@ -65,13 +65,13 @@ class LogicTest extends AnyFreeSpec with Matchers {
     "generates the correct configuration for a Leader" in {
       val testConf = Source.fromResource("ossec/cluster-input.conf").getLines().mkString("\n")
       val expectedConf = Source.fromResource("ossec/cluster-leader-output.conf").getLines().mkString("\n")
-      Logic.createConf(WazuhFiles(testConf), parameters, Leader, "10.0.0.1") shouldEqual WazuhFiles(expectedConf)
+      Logic.createConf(WazuhFiles(testConf), parameters, Leader, "10.0.0.1", Date.today) shouldEqual WazuhFiles(expectedConf)
     }
 
     "generates the correct configuration for a Worker" in {
       val testConf = Source.fromResource("ossec/cluster-input.conf").getLines().mkString("\n")
       val expectedConf = Source.fromResource("ossec/cluster-worker-output.conf").getLines().mkString("\n")
-      Logic.createConf(WazuhFiles(testConf), parameters, Worker, "10.0.0.1") shouldEqual WazuhFiles(expectedConf)
+      Logic.createConf(WazuhFiles(testConf), parameters, Worker, "10.0.0.2", Date.today) shouldEqual WazuhFiles(expectedConf)
     }
   }
 }


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! Please try to complete each section below.
For some guidance on how to write great pull requests, see our recommendations:
https://github.com/guardian/recommendations/blob/master/pull-requests.md 😁
-->

## What is the purpose of this change?

#### 👉  Adding methods to obtain the current date

The current date is required to configure the value of `only_logs_after` when ingesting logs from AWS S3 sources.

Since this value will change each day, this also guarantees a restart of the wazuh-manager service at least once a day which resolves the memory leaks that sometimes occur once the manager has been running for several days.

#### 👉  Add logback and configure logging

Format the logging and add a console appender and file appender via Logback. 
This PR also adds logger steps within the wazup method.

## What is the value of these changes and how do we measure success?

Logs from wazup will be written to `/var/log/wazup/wazup.log` and informative logging can be added to the service.
This will support upcoming work to ensure that the logs are collected and sent to CloudWatch.

If the value of `only_logs_after` is being set, the wazuh-manager service should restart at the beginning of each day.

## Any additional notes?

