### PR TITLE
Set nodeType via configuration file and space runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The configuration can use HOCON format and requires the following entries:
 
 ```
 wazup {
+  nodeType = ???
   bucket = ???
   bucketPath = ???
   parameterPrefix = ???

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,10 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "org.scalatest" %% "scalatest" % "3.2.2" % Test
     ),
+    javaOptions in Universal ++= Seq(
+      s"-Dpidfile.path=/dev/null",
+      s"-Dconfig.file=/etc/gu/wazup.conf",
+    ),
     serverLoading in Debian := Some(Systemd),
     debianPackageDependencies := Seq("java8-runtime-headless"),
     // daemonUser and daemonGroup must be scoped to Linux to be applied

--- a/src/main/scala/com/gu/wazup/Logic.scala
+++ b/src/main/scala/com/gu/wazup/Logic.scala
@@ -1,5 +1,6 @@
 package com.gu.wazup
 
+import com.gu.wazup.model._
 import org.joda.time.DateTime
 import software.amazon.awssdk.services.ssm.model.GetParametersByPathResponse
 import zio.ZIO
@@ -52,11 +53,8 @@ object Logic {
     effectBlocking(InetAddress.getLocalHost.getHostAddress).refineOrDie(_.getMessage)
   }
 
-  def getNodeType(instanceIp: String, parameters: WazuhParameters): NodeType = {
-    if (parameters.leaderAddress.contains(instanceIp)) Leader
-    else Worker
-  }
-
+  // Only one node in the cluster needs to ingest logs from GCP and AWS
+  // The GCP and AWS wodle sections are therefore removed for the Workers
   def configureWorker(ossecConf: String): String = {
     ossecConf.replace("<node_type>master</node_type>", "<node_type>worker</node_type>")
       .replaceAll("[\\s]*<gcp-pubsub>(?s)(.*)</gcp-pubsub>", "")

--- a/src/main/scala/com/gu/wazup/Main.scala
+++ b/src/main/scala/com/gu/wazup/Main.scala
@@ -4,8 +4,10 @@ import com.gu.wazup.aws.AWS
 import com.gu.wazup.config.WazupConfig
 import software.amazon.awssdk.regions.Region
 import zio.blocking.Blocking
+import zio.clock.Clock
 import zio.console.Console
-import zio.{ExitCode, URIO}
+import zio.duration.Duration
+import zio.{ExitCode, Schedule, URIO}
 
 
 object Main extends zio.App {
@@ -14,8 +16,9 @@ object Main extends zio.App {
   private val cwClient = AWS.cloudwatchClient("infosec", Region.of("eu-west-1"))
 
   private val config = WazupConfig.load()
+  private val spaced = Schedule.spaced(Duration.fromMillis(60000))
 
-  def run(args: List[String]): URIO[Console with Blocking, ExitCode] =
+  def run(args: List[String]): URIO[Console with Blocking with Clock, ExitCode] =
     Wazup.wazup(s3Client, ssmClient, config)
-      .forever.exitCode
+      .repeat(spaced).exitCode
 }

--- a/src/main/scala/com/gu/wazup/Wazup.scala
+++ b/src/main/scala/com/gu/wazup/Wazup.scala
@@ -32,7 +32,7 @@ object Wazup extends LazyLogging {
       _ <- IO(logger.info(s"Reading current configuration for ${config.nodeType} $nodeAddress"))
       shouldUpdate = Logic.hasChanges(newConf, currentConf)
       _ <- ZIO.when(shouldUpdate)(writeConf(config.confPath, newConf))
-      _ <- ZIO.when(shouldUpdate)(restartWazuh())
+      _ <- ZIO.when(shouldUpdate)(restartWazuh().map(ec => logger.info(s"Restart returned ExitCode: ${ec.code}")))
       // TODO: add CloudWatch logging step here
     } yield logger.info(s"Run complete! restart required was: $shouldUpdate")
 
@@ -85,7 +85,7 @@ object Wazup extends LazyLogging {
   }
 
   def restartWazuh(): ZIO[Blocking, String, ExitCode] = {
-    Command("systemctl", "restart", "wazuh-manager").run
+    Command("sudo", "systemctl", "restart", "wazuh-manager").run
       .flatMap(process => process.exitCode)
       .mapError(err => err.getMessage)
   }

--- a/src/main/scala/com/gu/wazup/config/WazupConfig.scala
+++ b/src/main/scala/com/gu/wazup/config/WazupConfig.scala
@@ -1,6 +1,6 @@
 package com.gu.wazup.config
 
-import com.gu.wazup.Configuration
+import com.gu.wazup.model.{Configuration, Leader, NodeType, Worker}
 import com.typesafe.config.{Config, ConfigException, ConfigFactory}
 
 import scala.util.Try
@@ -19,15 +19,21 @@ object WazupConfig {
 
   private def loadContents(config: Config): Either[String, Configuration] = {
     for {
+      nodeType <- handleErrors(config, "wazup.nodeType").map(getNodeType)
       bucket <- handleErrors(config, "wazup.bucket")
       bucketPath <- handleErrors(config, "wazup.bucketPath")
       parameterPrefix <- handleErrors(config, "wazup.parameterPrefix")
       confPath <- handleErrors(config, "wazup.confPath")
-    } yield Configuration(bucket, bucketPath, parameterPrefix, confPath)
+    } yield Configuration(nodeType, bucket, bucketPath, parameterPrefix, confPath)
   }
 
   private def handleErrors(config: Config, path: String): Either[String, String] = {
     Try(config.getString(path)).toEither.left.map(_.getMessage)
+  }
+
+  private[config] def getNodeType(nodeType: String): NodeType = {
+    if (nodeType == "Leader") Leader
+    else Worker
   }
 
   class WazupConfigException(message: String) extends ConfigException(message)

--- a/src/main/scala/com/gu/wazup/model/models.scala
+++ b/src/main/scala/com/gu/wazup/model/models.scala
@@ -1,11 +1,11 @@
-package com.gu.wazup
-
+package com.gu.wazup.model
 
 sealed trait NodeType
 case object Leader extends NodeType
 case object Worker extends NodeType
 
 case class Configuration(
+  nodeType: NodeType,
   bucket: String,
   bucketPath: String,
   parameterPrefix: String,

--- a/src/test/scala/com/gu/wazup/LogicTest.scala
+++ b/src/test/scala/com/gu/wazup/LogicTest.scala
@@ -1,5 +1,6 @@
 package com.gu.wazup
 
+import com.gu.wazup.model.{ConfigFile, Leader, WazuhFiles, WazuhParameters, Worker}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -22,17 +23,6 @@ class LogicTest extends AnyFreeSpec with Matchers {
         Some("FAKEKEY"), Some("10.0.0.1"))
 
       Logic.parseParameters(response, "/wazuh/TEST/") shouldEqual expected
-    }
-  }
-
-  "getNodeType" - {
-    val parameters = WazuhParameters(None, Some("10.0.0.1"))
-
-    "returns Leader when the addresses match" in {
-      Logic.getNodeType("10.0.0.1", parameters) shouldEqual Leader
-    }
-    "returns Worker when the addresses are different" in {
-      Logic.getNodeType("10.0.0.2", parameters) shouldEqual Worker
     }
   }
 

--- a/src/test/scala/com/gu/wazup/config/WazupConfigTest.scala
+++ b/src/test/scala/com/gu/wazup/config/WazupConfigTest.scala
@@ -1,0 +1,21 @@
+package com.gu.wazup.config
+
+import com.gu.wazup.model.{Leader, Worker}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+
+class WazupConfigTest extends AnyFreeSpec with Matchers {
+
+  "getNodeType" - {
+
+    "returns Leader when the addresses match" in {
+      WazupConfig.getNodeType("Leader") shouldEqual Leader
+    }
+    "returns Worker when the addresses are different" in {
+      WazupConfig.getNodeType("Worker") shouldEqual Worker
+      WazupConfig.getNodeType("None") shouldEqual Worker
+    }
+  }
+
+}


### PR DESCRIPTION
## What is the purpose of this change?

#### 👉  Set config file location in Universal

The wazup service will load the configuration file `/etc/gu/wazup.conf` when the service starts. This file can be created as part of the UserData of an EC2 instance and is intended to contain static settings for wazup.

When developing or testing wazup locally, system properties can be used to force a different (replacement) config source:

```
sbt -Dconfig.file=<PATH>/wazup.local.conf run
```

#### 👉  Use the configuration file to determine nodeType

When operating Wazuh as a cluster there should be exactly one leader node and one or more worker nodes. The the wazuh clusterd service does not support leader elections and it would be rather ambitious to attempt to add cluster management to wazup.

The nodetype (`Leader` / `Worker`) causes different configurations for the types of cluster node and is set according to the contents of the wazup configuration file as it should not change over the lifecycle of the instance.

#### 👉  Use sudo when restarting and log the ExitCode

To restart the wazuh-manager service the command needs to be run as sudo. See the additional notes section for more information. 

Logging the ExitCode is useful to see if the call to systemctl succeeded.

#### 👉  Add a 60 second space between each run

Wazup currently loops very quickly, which makes things difficult for any humans that are trying to read the logs while the service is active. Since wazup also makes requests to AWS S3 and AWS Parameter Store on each run, limiting the frequency might be a helpful measure against API rate limiting and spiralling request based costs. 💸 💸 

ZIO supports [many types](https://zio.dev/docs/datatypes/misc/schedule#base-schedules) of base schedule, including one that recurs continuously, each repetition spaced the specified duration from the last run. Switching from `forever` to `spaced` with a duration of 60 seconds ensures that wazup runs no more than once each minute:

<img width="1197" alt="Screenshot 2021-06-04 at 17 04 37" src="https://user-images.githubusercontent.com/8607683/121182379-f18b9280-c85a-11eb-9ced-db579696ee85.png">

## What is the value of this change and how do we measure success?

Working wazup service

## Any additional notes?

It is also necessary to give wazup the sudo permissions required to manage the lifecycle of the wazuh-manager service.
The wazup service runs under the wazup user, therefore running the following on the EC2 instance (as part of the UserData) will give the correct permissions:

```bash
cat > /etc/sudoers.d/wazup << SUDO
wazup ALL= NOPASSWD: /bin/systemctl restart wazuh-manager
wazup ALL= NOPASSWD: /bin/systemctl stop wazuh-manager
wazup ALL= NOPASSWD: /bin/systemctl start wazuh-manager
SUDO
```

More information and alternative approaches can be found in [this StackExchange post](https://unix.stackexchange.com/questions/496982/restarting-systemd-service-only-as-a-specific-user)

