### PR TITLE
Check whether wazuh-manager is running and restart service if not

### DIFF
--- a/src/main/scala/com/gu/wazup/Logic.scala
+++ b/src/main/scala/com/gu/wazup/Logic.scala
@@ -69,8 +69,8 @@ object Logic {
   }
 
   def notRunning(): ZIO[Blocking, String, Boolean] = {
-    Command("systemctl", "status", "wazuh-manager").successfulExitCode
-      .mapEffect(process => process.code == 0)
+    Command("systemctl", "status", "wazuh-manager").exitCode
+      .mapEffect(process => process.code != 0)
       .mapError(err => err.getMessage)
   }
 

--- a/src/main/scala/com/gu/wazup/Wazup.scala
+++ b/src/main/scala/com/gu/wazup/Wazup.scala
@@ -30,12 +30,13 @@ object Wazup extends LazyLogging {
       newConf = Logic.createConf(wazuhFiles, wazuhParameters, config.nodeType, nodeAddress, Date.today)
       currentConf <- getCurrentConf(configFiles.map(_.filename), config.bucketPath, config.confPath)
       _ <- IO(logger.info(s"Reading current configuration for ${config.nodeType} $nodeAddress"))
-      shouldUpdate = Logic.hasChanges(newConf, currentConf)
+      hasChanges = Logic.hasChanges(newConf, currentConf)
       notRunning <- Logic.notRunning()
-      _ <- ZIO.when(shouldUpdate)(writeConf(config.confPath, newConf))
-      _ <- ZIO.when(shouldUpdate || notRunning)(restartWazuh().map(ec => logger.info(s"Restart returned ExitCode: ${ec.code}")))
+      shouldRestart = (hasChanges || notRunning)
+      _ <- ZIO.when(shouldRestart)(writeConf(config.confPath, newConf))
+      _ <- ZIO.when(shouldRestart || notRunning)(restartWazuh().map(ec => logger.info(s"Restart returned ExitCode: ${ec.code}")))
       // TODO: add CloudWatch logging step here
-    } yield logger.info(s"Run complete! restart required was: $shouldUpdate")
+    } yield logger.info(s"Run complete! restart required was: $shouldRestart")
 
     result.fold(err => logger.error(err.toString), identity)
   }


### PR DESCRIPTION
## What is the purpose of this change?

Wazuh-manager can sometimes fail at the nightly restarts performed by wazup. The condition causing the failure hasn't been fully understood, but it does appear to be a spurious one caused by race conditions in the wazuh-manager init script. This change will add an additional check, to see whether the process is running or not. If either condition (config file changed, process not running) are true, then wazup will restart wazuh-manager. 

## What is the value of this change and how do we measure success?

This will make sure wazup attempts to make sure wazuh-manager is running, whatever state it's in. 

## Any additional notes?

It would be nice to have wazup report its success to cloudwatch. 