### PR TITLE
Get hive SSM parameter path from SSM and add it to ossec.conf

### DIFF
--- a/src/main/scala/com/gu/wazup/Logic.scala
+++ b/src/main/scala/com/gu/wazup/Logic.scala
@@ -26,6 +26,7 @@ object Logic {
       // TODO: should missing parameters raise an exception?
       parameters.get("cluster-key"),
       parameters.get("leader-address"),
+      parameters.get("hive-param-path")
     )
   }
 
@@ -47,6 +48,7 @@ object Logic {
       .replaceAll("<key>.+</key>", s"<key>${parameters.clusterKey.getOrElse("")}</key>")
       .replaceAll("<node>.+</node>", s"<node>${parameters.leaderAddress.getOrElse("")}</node>")
       .replaceAll("<only_logs_after>.+</only_logs_after>", s"<only_logs_after>${Date.formatDate(logsAfter)}</only_logs_after>")
+      .replaceAll("<api_key>.+</api_key>", s"<api_key>${parameters.hiveParamPath.getOrElse("")}</api_key>")
     if (nodeType == Worker) wazuhFiles.copy(ossecConf = configureWorker(newConf))
     else wazuhFiles.copy(ossecConf = newConf)
   }

--- a/src/main/scala/com/gu/wazup/model/models.scala
+++ b/src/main/scala/com/gu/wazup/model/models.scala
@@ -20,6 +20,7 @@ case class WazuhConf(
 case class WazuhParameters(
   clusterKey: Option[String],
   leaderAddress: Option[String],
+  hiveParamPath: Option[String],
 )
 
 case class WazuhFiles(

--- a/src/test/scala/com/gu/wazup/LogicTest.scala
+++ b/src/test/scala/com/gu/wazup/LogicTest.scala
@@ -17,10 +17,11 @@ class LogicTest extends AnyFreeSpec with Matchers {
         GetParametersByPathResponse.builder().parameters(
           Parameter.builder().name("/wazuh/TEST/cluster-key").value("FAKEKEY").build(),
           Parameter.builder().name("/wazuh/TEST/leader-address").value("10.0.0.1").build(),
+          Parameter.builder().name("/wazuh/TEST/hive-param-path").value("/hive/CODE/thehive").build(),
         ).build()
       }
       val expected = WazuhParameters(
-        Some("FAKEKEY"), Some("10.0.0.1"))
+        Some("FAKEKEY"), Some("10.0.0.1"), Some("/hive/CODE/thehive"))
 
       Logic.parseParameters(response, "/wazuh/TEST/") shouldEqual expected
     }
@@ -45,6 +46,7 @@ class LogicTest extends AnyFreeSpec with Matchers {
     val parameters: WazuhParameters = WazuhParameters(
       Some("12345FAKEKEY"),
       Some("10.0.0.1"),
+      Some("/hive/CODE/thehive")
     )
 
     "generates the correct configuration for a Leader" in {


### PR DESCRIPTION
Wazuh integration config lives in ossec.conf - each integration needs a name, hook_url, and api_key. The name must line up with the script found in /var/ossec/integrations/custom-$name - in this case custom-thehive, which is a bash wrapper around /var/ossec/integrations/custom-thehive.py. The and api_key and hook_url will be supplied to the script as the second and third arguments respectively, with the first argument being the path to the file containing alert json. 

The integration with wazuh is designed to get the api_key and hook_url from AWS SSM parameter store, so instead of providing an API key, an SSM parameter path is provided instead, which can be used to lookup both the API key and webhook endpoint. 

## What is the purpose of this change?

Wazup will need to replace the value of api_key in ossec.conf. This will let Wazuh raise cases in TheHive above an alert threshold. 

## What is the value of this change and how do we measure success?

Wazuh alerts above a configurable threshold will raise cases in TheHive. 
