### PR TITLE
Remove azure-logs config section from workers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val root = (project in file("."))
     debianPackageDependencies := Seq("java8-runtime-headless"),
     // daemonUser and daemonGroup must be scoped to Linux to be applied
     // membership of ossec gives wazup permission to modify /var/ossec/
-    daemonGroup in Linux := "ossec",
+    daemonGroup in Linux := "wazuh",
 
     maintainer in Debian := "Security Engineering",
     packageSummary in Debian := "Wazup: Automatically update Wazuh configuration",

--- a/src/main/scala/com/gu/wazup/Logic.scala
+++ b/src/main/scala/com/gu/wazup/Logic.scala
@@ -63,6 +63,8 @@ object Logic {
     ossecConf.replace("<node_type>master</node_type>", "<node_type>worker</node_type>")
       .replaceAll("[\\s]*<gcp-pubsub>(?s)(.*)</gcp-pubsub>", "")
       .replaceAll("[\\s]*<wodle name=\"aws-s3\">(?s)(.*)</wodle>", "")
+      .replaceAll("[\\s]*<wodle name=\"azure-logs\">(?s)(.*)</wodle>", "")
+      .replaceAll("[\\s]*<geoipdb>(?s)(.*)</geoipdb>", "")
   }
 
   def hasChanges(incoming: WazuhFiles, current: WazuhFiles): Boolean = {


### PR DESCRIPTION
## What is the purpose of this change?

This change enables the use of the azure-logs wodle alongside wazup, in a clustered wazuh environment. At present the gcp-pubsub and aws-s3 sections are removed from the worker configs, in order to not retrieve duplicate logs. The azure-logs section should also be removed in a similar way.

The geoipdb section is also not required on worker nodes. 

As of Wazuh 4.2, the linux user and group for the wazuh service were changed from "ossec:ossec" to "wazuh:wazuh". This change is reflected here, as wazup must be able to modify the contents of ossec.conf. 